### PR TITLE
fix timeouts for larger libraries

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,7 +49,8 @@ def get_server_thumbnail():
 
 @app.route("/content/dupes")
 def get_dupes():
-    dupes = PlexWrapper().get_dupe_content()
+    page = int(request.args.get("page", 1))
+    dupes = PlexWrapper().get_dupe_content(page)
     return jsonify(dupes)
 
 

--- a/backend/plexwrapper.py
+++ b/backend/plexwrapper.py
@@ -54,7 +54,7 @@ class PlexWrapper(object):
             'url': self.baseurl + '/web/index.html'
         }
 
-    def get_dupe_content(self):
+    def get_dupe_content(self, page=1):
         logger.debug("START")
         dupes = []
         for section in self._get_sections():
@@ -62,38 +62,31 @@ class PlexWrapper(object):
             if section.type == "movie":
                 logger.debug("Section type is MOVIE")
                 # Recursively search movies
-                offset = 0
-                end = False
-                while not end:
-                    limit = offset + self.page_size
-                    logger.debug("Get results from offset %s to limit %s", offset, limit)
-                    results = section.search(duplicate=True, libtype='movie', container_start=offset, limit=limit)
-                    if len(results) == 0:
-                        end = True
-                    else:
-                        offset += self.page_size
-                        for movie in results:
-                            if len(movie.media) > 1:
-                                logger.debug("Found media: %s", movie.guid)
-                                dupes.append(self.movie_to_dict(movie, section.title))
-
-            if section.type == "show":
+                offset = (page - 1) * self.page_size
+                limit = offset + self.page_size
+                logger.debug("Get results from offset %s to limit %s", offset, limit)
+                results = section.search(duplicate=True, libtype='movie', container_start=offset, limit=limit)
+                if len(results) == 0:
+                    continue
+                else:
+                    for movie in results:
+                        if len(movie.media) > 1:
+                            logger.debug("Found media: %s", movie.guid)
+                            dupes.append(self.movie_to_dict(movie, section.title))
+            elif section.type == "show":
                 logger.debug("Section type is SHOW")
                 # Recursively search TV
-                offset = 0
-                end = False
-                while not end:
-                    limit = offset + self.page_size
-                    logger.debug("Get results from offset %s to limit %s", offset, limit)
-                    results = section.search(duplicate=True, libtype='episode', container_start=offset, limit=limit)
-                    if len(results) == 0:
-                        end = True
-                    else:
-                        offset += self.page_size
-                        for episode in results:
-                            if len(episode.media) > 1:
-                                logger.debug("Found media: %s", episode.guid)
-                                dupes.append(self.episode_to_dict(episode, section.title))
+                offset = (page - 1) * self.page_size
+                limit = offset + self.page_size
+                logger.debug("Get results from offset %s to limit %s", offset, limit)
+                results = section.search(duplicate=True, libtype='episode', container_start=offset, limit=limit)
+                if len(results) == 0:
+                    continue
+                else:
+                    for episode in results:
+                        if len(episode.media) > 1:
+                            logger.debug("Found media: %s", episode.guid)
+                            dupes.append(self.episode_to_dict(episode, section.title))
         return dupes
 
     def get_content_sample_files(self):

--- a/frontend/src/util/api.ts
+++ b/frontend/src/util/api.ts
@@ -22,8 +22,8 @@ export const getDeletedSizes = (): Promise<any> => {
   return axios.get(DELETED_SIZES);
 };
 
-export const getDupeContent = (): Promise<any> => {
-  return axios.get(DUPES_URL);
+export const getDupeContent = (page: number = 1): Promise<any> => {
+  return axios.get(`${DUPES_URL}?page=${page}`);
 };
 
 export const getSampleContent = (): Promise<any> => {


### PR DESCRIPTION
**What does this PR do?**

tl;dr; moves `while not end` to the UI and performs sections of this loop asyncronously. You can test this change with `docker pull pemcconnell/cleanarr`

Updates `get_dupe_content` so that it accepts a `page` parameter instead of running inside a while loop - this moves the paging iteration outside of this function, allowing us to create external paging mechanisms. It then updates the `get_dupes` method so it takes an optional `page` argument, which gets passed to the `get_dupe_content` method - this moves the paging iteration to the uri level. Lastly it updates the `loadDupeContent` method in the frontend code so that it will essentially be responsible for the _original_ `while not end` logic. This puts an HTTP request between each paging of the results. Shouldn't be too noticable perf wise for existing usecases, but keen for validation there. I'm expecting a speed up for all usecases due to the async batching this PR introduces but I don't have a way to easily test for this. Importantly this means that Cleanarr now works on larger datasets.

An optimisation added that executes dupes requests in batches of `PAGE_SIZE` asyncronously. This defaults to 10 but can be overwritten with a new env `REACT_APP_PAGE_SIZE`. Cost: some needless calls to the dupes api. Reward: total time to load decreased for users in the UI. Due to this asyncronous logic this PR makes larger libraries not only work, but do so much faster (for me I went from ~90 second load time to ~15 after the async patch). 15 seconds is still way to long and I suspect 504s are still technically possible, but this is a reasonable start.

**What does this not do?**

I made no attempt to optimise any of the existing logic or external calls, aside from the asyncronous batching of ?page=X to ?page=Y. I suspect many opportunities for perf improvements remain in breaking the dupes api call up further, caching and/or reducing the number of properties requested.
I made no attempt at adding visual cues for the paging in the UI.
I didn't write tests. Sorry. I have limited time and wanted to hack something together in 30 mins and am not familiar with typescript so this wasn't fluent for me.
I haven't yet tested other parts of the software with my library - if I find other issues I'll try to patch and PR as I go

**Caveats**

I have never written typescript before. No clue if what I wrote is clean / idiosyncratic, but it seems to work.

**How was it tested / how should a reviewer test it?**

 - I ran this against my local instance which reliably 504s. It now works every time. You can see the paging in the console:
![image](https://user-images.githubusercontent.com/641429/226841741-cb090792-5ce0-422d-bc62-03067229f028.png)
 - I'd appreciate some testing on scenarios that worked previously to ensure I'm not introducing noticable degradations.
 - General code review; esp. for the typescript

Scanning over the open issues I believe this will solve the following:

Closes #55 
Closes #57 
Closes #60 
Closes #62 
Closes #66 
Closes #77 
Closes #70 