### PR TITLE
chore: get_dupes refactor and benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ build: .env
 run:
 	@opts=""; if [ "$(CONFIG_MOUNT)" != "" ]; then opts="$$opts -v $(CONFIG_MOUNT):/config"; fi; \
 	docker run --rm --env-file=.env -p $(HOST_PORT):$(CONTAINER_PORT) $$opts -ti $(IMG_NAME)
+
+.PHONY: benchmark_backend
+benchmark_backend:
+	@cd backend && PYTHONPATH=$$(pwd) pytest -v benchmarks.py

--- a/backend/benchmarks.py
+++ b/backend/benchmarks.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+# this file is meant for local development only. it expects a populated .env file
+# with connection details to a valid plex server. it can be run via pytest, which
+# will run multiple iterations and rounds of the get_dupe_content method, or can
+# be invoked directly with ./backend/benchmark.py to simply run get_dupe_content()
+# and print traces to stdout (note: traces only available if DEBUG=1 set)
+
+import pytest
+import time
+from plexwrapper import PlexWrapper
+from utils import print_top_traces
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def get_dupe_content():
+    PlexWrapper().get_dupe_content()
+
+def test_get_dupe_content(benchmark):
+    benchmark.pedantic(get_dupe_content, iterations=10, rounds=3)
+
+
+# allow for direct invocation, without pytest
+if __name__ == "__main__":
+    get_dupe_content()
+    print_top_traces(10)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,5 @@ tqdm==4.42.0
 urllib3==1.26.18
 websocket-client==0.57.0
 Werkzeug==3.0.1
+python-dotenv==1.0.0
+pytest-benchmark==4.0.0


### PR DESCRIPTION
further optimisations to the get_dupes method

added a helper decorator for recording and printing method execution times if in DEBUG=1 mode

added a simple benchmark script for testing get_dupes against a live plex instance